### PR TITLE
Handle Supabase session overwrites cleanly

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next", "next/core-web-vitals"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 /.vscode
+/node_modules
+/.next
+/out
+.DS_Store
+
+# Supabase
+/supabase/.temp

--- a/__tests__/drawings.test.ts
+++ b/__tests__/drawings.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createDrawing, MaxSessionsError, renameDrawing, updateDrawing } from '@/lib/drawings';
+import type { Drawing } from '@/lib/drawings';
+
+vi.mock('@/lib/supabaseClient', () => {
+  return {
+    getSupabaseClient: vi.fn()
+  };
+});
+
+const { getSupabaseClient } = await import('@/lib/supabaseClient');
+
+type MockSupabaseClient = {
+  auth: {
+    getUser: ReturnType<typeof vi.fn>;
+  };
+  from: ReturnType<typeof vi.fn>;
+  storage: {
+    from: ReturnType<typeof vi.fn>;
+  };
+};
+
+function createClient(): MockSupabaseClient {
+  return {
+    auth: {
+      getUser: vi.fn(async () => ({ data: { user: { id: 'user-1' } }, error: null }))
+    },
+    from: vi.fn(),
+    storage: {
+      from: vi.fn(() => ({
+        upload: vi.fn(async () => ({ data: null, error: null })),
+        remove: vi.fn(async () => ({ data: null, error: null })),
+        createSignedUrl: vi.fn(async () => ({ data: { signedUrl: 'https://example.com/signed' }, error: null }))
+      }))
+    }
+  };
+}
+
+function mockCountQuery(client: MockSupabaseClient, count: number, error: unknown = null) {
+  client.from.mockImplementationOnce(() => ({
+    select: vi.fn(async () => ({ count, error }))
+  }));
+}
+
+function mockInsertQuery(client: MockSupabaseClient, drawing: Drawing, error: unknown = null) {
+  client.from.mockImplementationOnce(() => ({
+    insert: vi.fn(() => ({
+      select: vi.fn(() => ({
+        single: vi.fn(async () => ({ data: error ? null : drawing, error }))
+      }))
+    }))
+  }));
+}
+
+function mockRenameQuery(client: MockSupabaseClient, error: unknown = null) {
+  client.from.mockImplementationOnce(() => ({
+    update: vi.fn(() => ({
+      eq: vi.fn(async () => ({ error }))
+    }))
+  }));
+}
+
+function mockUpdateQuery(client: MockSupabaseClient, error: unknown = null) {
+  client.from.mockImplementationOnce(() => ({
+    update: vi.fn(() => ({
+      eq: vi.fn(async () => ({ error }))
+    }))
+  }));
+}
+
+const getSupabaseClientMock = getSupabaseClient as unknown as ReturnType<typeof vi.fn>;
+
+describe('drawings library', () => {
+  let client: MockSupabaseClient;
+
+  beforeEach(() => {
+    getSupabaseClientMock.mockReset();
+    client = createClient();
+    getSupabaseClientMock.mockReturnValue(client);
+  });
+
+  it('creates a drawing when under the limit', async () => {
+    const drawing: Drawing = {
+      id: 'drawing-1',
+      owner: 'user-1',
+      title: 'Warehouse A',
+      elements: [],
+      bg_image_path: null,
+      updated_at: new Date().toISOString()
+    };
+    mockCountQuery(client, 1);
+    mockInsertQuery(client, drawing);
+
+    const result = await createDrawing('Warehouse A', []);
+
+    expect(result).toEqual(drawing);
+    expect(client.from).toHaveBeenNthCalledWith(1, 'drawings');
+    expect(client.from).toHaveBeenNthCalledWith(2, 'drawings');
+  });
+
+  it('throws MaxSessionsError when the limit is reached', async () => {
+    mockCountQuery(client, 3);
+
+    await expect(createDrawing('Overflow', [])).rejects.toBeInstanceOf(MaxSessionsError);
+  });
+
+  it('surface duplicate title errors from renameDrawing', async () => {
+    mockRenameQuery(client, { code: '23505', message: 'duplicate key value violates unique constraint' });
+
+    await expect(renameDrawing('drawing-1', 'Conflict')).rejects.toThrow(
+      'You already have a session with that name.'
+    );
+  });
+
+  it('returns the uploaded background path when updating with a new file', async () => {
+    mockUpdateQuery(client);
+    const file = new File(['test'], 'bg.png', { type: 'image/png' });
+
+    const result = await updateDrawing('drawing-1', [], file);
+
+    expect(result).toBe('user-1/drawing-1.png');
+  });
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,24 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  cursor: pointer;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,22 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import { ToastProvider } from '@/components/ToastProvider';
+
+export const metadata: Metadata = {
+  title: 'SlipBot Studio',
+  description: 'Plan warehouse sessions with SlipBot drag-and-drop canvas.'
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <ToastProvider>{children}</ToastProvider>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { DrawingProvider, useDrawing } from '@/components/DrawingContext';
+import { BackgroundUploader } from '@/components/BackgroundUploader';
+import { CanvasStage } from '@/components/CanvasStage';
+import { SaveSessionButton } from '@/components/SaveSessionButton';
+import { SessionsDropdown } from '@/components/SessionsDropdown';
+import { useToast } from '@/components/ToastProvider';
+import { listDrawings, type Drawing } from '@/lib/drawings';
+
+function PageInner() {
+  const [sessions, setSessions] = useState<Drawing[]>([]);
+  const [loadingSessions, setLoadingSessions] = useState(false);
+  const { showToast } = useToast();
+  const { currentDrawingTitle } = useDrawing();
+
+  const refreshSessions = useCallback(async () => {
+    setLoadingSessions(true);
+    try {
+      const data = await listDrawings();
+      setSessions(data);
+    } catch (error) {
+      if (error instanceof Error) {
+        showToast(error.message, 'error');
+      } else {
+        showToast('Unable to load sessions.', 'error');
+      }
+    } finally {
+      setLoadingSessions(false);
+    }
+  }, [showToast]);
+
+  useEffect(() => {
+    void refreshSessions();
+  }, [refreshSessions]);
+
+  return (
+    <main
+      style={{
+        padding: '48px clamp(24px, 5vw, 60px)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 32,
+        maxWidth: 1100,
+        margin: '0 auto'
+      }}
+    >
+      <header style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <h1 style={{ margin: 0, fontSize: '2rem' }}>SlipBot Studio</h1>
+        <p style={{ margin: 0, color: '#94a3b8', maxWidth: 720 }}>
+          Drag warehouse assets into the scene, upload a background floor plan, and save up to three sessions per account. Sessions
+          store your entire layout, including the background image.
+        </p>
+      </header>
+      <section style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 16,
+            alignItems: 'center'
+          }}
+        >
+          <SaveSessionButton sessionCount={sessions.length} onSessionsChanged={refreshSessions} />
+          <SessionsDropdown sessions={sessions} onRefresh={refreshSessions} isLoading={loadingSessions} />
+          <BackgroundUploader />
+        </div>
+        <div style={{ color: '#94a3b8', fontSize: 14 }}>
+          {currentDrawingTitle ? `Working on “${currentDrawingTitle}”` : 'Unsaved session'}
+        </div>
+      </section>
+      <CanvasStage />
+    </main>
+  );
+}
+
+export default function Page() {
+  return (
+    <DrawingProvider>
+      <PageInner />
+    </DrawingProvider>
+  );
+}

--- a/components/BackgroundUploader.tsx
+++ b/components/BackgroundUploader.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import React, { ChangeEvent } from 'react';
+import { useDrawing } from '@/components/DrawingContext';
+
+export function BackgroundUploader() {
+  const { backgroundUrl, setBackgroundFile } = useDrawing();
+
+  const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      setBackgroundFile(file);
+    }
+  };
+
+  return (
+    <label
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '8px 12px',
+        borderRadius: 8,
+        border: '1px dashed rgba(148, 163, 184, 0.4)',
+        color: '#e2e8f0',
+        cursor: 'pointer'
+      }}
+    >
+      <input type="file" accept="image/*" style={{ display: 'none' }} onChange={handleFileChange} />
+      {backgroundUrl ? 'Replace background image' : 'Upload background image'}
+    </label>
+  );
+}

--- a/components/CanvasStage.tsx
+++ b/components/CanvasStage.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useCallback } from 'react';
+import Image from 'next/image';
 import { useDrawing } from '@/components/DrawingContext';
 
 export function CanvasStage() {
@@ -110,20 +111,28 @@ export function CanvasStage() {
             );
           }
           if (element.type === 'image' && element.src) {
+            const width = element.w ?? 80;
+            const height = element.h ?? 80;
             return (
-              <img
+              <div
                 key={element.id}
-                src={element.src}
-                alt="Scene asset"
                 style={{
                   position: 'absolute',
                   left: element.x,
                   top: element.y,
-                  width: element.w ?? 80,
-                  height: element.h ?? 80,
-                  objectFit: 'contain'
+                  width,
+                  height
                 }}
-              />
+              >
+                <Image
+                  src={element.src}
+                  alt="Scene asset"
+                  fill
+                  unoptimized
+                  style={{ objectFit: 'contain' }}
+                  sizes={`${width}px`}
+                />
+              </div>
             );
           }
           return null;

--- a/components/CanvasStage.tsx
+++ b/components/CanvasStage.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import React, { useCallback } from 'react';
+import { useDrawing } from '@/components/DrawingContext';
+
+export function CanvasStage() {
+  const { elements, setScene, backgroundUrl } = useDrawing();
+
+  const addRectangle = useCallback(() => {
+    setScene([
+      ...elements,
+      {
+        id: crypto.randomUUID(),
+        type: 'rect' as const,
+        x: Math.floor(Math.random() * 400),
+        y: Math.floor(Math.random() * 220),
+        w: 80,
+        h: 60,
+        style: { fill: '#38bdf8' }
+      }
+    ]);
+  }, [elements, setScene]);
+
+  const clearScene = useCallback(() => {
+    setScene([]);
+  }, [setScene]);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 16,
+        width: '100%'
+      }}
+    >
+      <div style={{ display: 'flex', gap: 12 }}>
+        <button
+          type="button"
+          onClick={addRectangle}
+          style={{
+            padding: '8px 12px',
+            borderRadius: 8,
+            border: '1px solid rgba(148, 163, 184, 0.4)',
+            background: 'transparent',
+            color: '#e2e8f0'
+          }}
+        >
+          Add rectangle
+        </button>
+        <button
+          type="button"
+          onClick={clearScene}
+          style={{
+            padding: '8px 12px',
+            borderRadius: 8,
+            border: '1px solid rgba(248, 113, 113, 0.4)',
+            background: 'transparent',
+            color: '#f87171'
+          }}
+        >
+          Clear scene
+        </button>
+      </div>
+      <div
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: 400,
+          borderRadius: 16,
+          overflow: 'hidden',
+          backgroundColor: '#111827',
+          backgroundImage: backgroundUrl ? `url(${backgroundUrl})` : undefined,
+          backgroundSize: 'cover',
+          backgroundPosition: 'center'
+        }}
+      >
+        {elements.map((element) => {
+          if (element.type === 'rect') {
+            return (
+              <div
+                key={element.id}
+                style={{
+                  position: 'absolute',
+                  left: element.x,
+                  top: element.y,
+                  width: element.w ?? 80,
+                  height: element.h ?? 60,
+                  borderRadius: 8,
+                  backgroundColor: (element.style?.fill as string) ?? 'rgba(59, 130, 246, 0.7)',
+                  boxShadow: '0 10px 25px rgba(15, 23, 42, 0.4)'
+                }}
+              />
+            );
+          }
+          if (element.type === 'text') {
+            return (
+              <span
+                key={element.id}
+                style={{
+                  position: 'absolute',
+                  left: element.x,
+                  top: element.y,
+                  color: '#f8fafc',
+                  fontWeight: 600
+                }}
+              >
+                {element.text ?? 'Label'}
+              </span>
+            );
+          }
+          if (element.type === 'image' && element.src) {
+            return (
+              <img
+                key={element.id}
+                src={element.src}
+                alt="Scene asset"
+                style={{
+                  position: 'absolute',
+                  left: element.x,
+                  top: element.y,
+                  width: element.w ?? 80,
+                  height: element.h ?? 80,
+                  objectFit: 'contain'
+                }}
+              />
+            );
+          }
+          return null;
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/DrawingContext.tsx
+++ b/components/DrawingContext.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import React, { createContext, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import type { SceneElement } from '@/lib/drawings';
+
+type DrawingContextValue = {
+  currentDrawingId: string | null;
+  currentDrawingTitle: string | null;
+  elements: SceneElement[];
+  backgroundUrl: string | null;
+  backgroundPath: string | null;
+  backgroundFile: File | null;
+  setCurrentDrawingId: (id: string | null) => void;
+  setCurrentDrawingTitle: (title: string | null) => void;
+  setScene: (next: SceneElement[]) => void;
+  getScene: () => SceneElement[];
+  setBackgroundFromUrl: (url: string | null) => void;
+  setBackgroundPath: (path: string | null) => void;
+  setBackgroundFile: (file: File | null) => void;
+  commitBackground: (path: string | null, url?: string | null) => void;
+};
+
+const DrawingContext = createContext<DrawingContextValue | undefined>(undefined);
+
+export function DrawingProvider({ children }: { children: React.ReactNode }) {
+  const [currentDrawingId, setCurrentDrawingId] = useState<string | null>(null);
+  const [currentDrawingTitle, setCurrentDrawingTitle] = useState<string | null>(null);
+  const [elements, setElements] = useState<SceneElement[]>([]);
+  const [backgroundUrl, setBackgroundUrl] = useState<string | null>(null);
+  const [backgroundPath, setBackgroundPathState] = useState<string | null>(null);
+  const [backgroundFile, setBackgroundFileState] = useState<File | null>(null);
+  const objectUrlRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current);
+        objectUrlRef.current = null;
+      }
+    };
+  }, []);
+
+  const value = useMemo<DrawingContextValue>(() => {
+    const revokeObjectUrl = () => {
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current);
+        objectUrlRef.current = null;
+      }
+    };
+
+    return {
+      currentDrawingId,
+      currentDrawingTitle,
+      elements,
+      backgroundUrl,
+      backgroundPath,
+      backgroundFile,
+      setCurrentDrawingId,
+      setCurrentDrawingTitle,
+      setScene: (next) => {
+        setElements(next);
+      },
+      getScene: () => elements,
+      setBackgroundFromUrl: (url) => {
+        revokeObjectUrl();
+        setBackgroundUrl(url);
+        setBackgroundFileState(null);
+      },
+        setBackgroundPath: (path) => {
+          setBackgroundPathState(path);
+        },
+      setBackgroundFile: (file) => {
+        revokeObjectUrl();
+        setBackgroundFileState(file);
+        if (file) {
+          const objectUrl = URL.createObjectURL(file);
+          objectUrlRef.current = objectUrl;
+          setBackgroundUrl(objectUrl);
+          setBackgroundPathState(null);
+        } else {
+          setBackgroundUrl(null);
+          setBackgroundPathState(null);
+        }
+      },
+      commitBackground: (path, url) => {
+        if (typeof url !== 'undefined') {
+          revokeObjectUrl();
+          setBackgroundUrl(url);
+        }
+        setBackgroundPathState(path);
+        setBackgroundFileState(null);
+      }
+    };
+  }, [backgroundFile, backgroundPath, backgroundUrl, currentDrawingId, currentDrawingTitle, elements]);
+
+  return <DrawingContext.Provider value={value}>{children}</DrawingContext.Provider>;
+}
+
+export function useDrawing() {
+  const ctx = useContext(DrawingContext);
+  if (!ctx) {
+    throw new Error('useDrawing must be used within a DrawingProvider');
+  }
+  return ctx;
+}

--- a/components/SaveSessionButton.tsx
+++ b/components/SaveSessionButton.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import React, { useCallback, useMemo, useState } from 'react';
+import { MaxSessionsError, createDrawing, updateDrawing } from '@/lib/drawings';
+import { useDrawing } from '@/components/DrawingContext';
+import { useToast } from '@/components/ToastProvider';
+
+type SaveSessionButtonProps = {
+  sessionCount: number;
+  onSessionsChanged: () => Promise<void>;
+};
+
+async function cloneFileFromUrl(url: string): Promise<File> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error('Unable to download background image for saving.');
+  }
+  const blob = await response.blob();
+  const extension = blob.type.split('/')[1] ?? 'png';
+  return new File([blob], `background.${extension}`, { type: blob.type || 'image/png' });
+}
+
+export function SaveSessionButton({ sessionCount, onSessionsChanged }: SaveSessionButtonProps) {
+  const {
+    currentDrawingId,
+    currentDrawingTitle,
+    getScene,
+    backgroundFile,
+    backgroundUrl,
+    backgroundPath,
+    setCurrentDrawingId,
+    setCurrentDrawingTitle,
+    commitBackground
+  } = useDrawing();
+  const { showToast } = useToast();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const hasCurrentDrawing = useMemo(() => Boolean(currentDrawingId), [currentDrawingId]);
+
+  const saveAsDisabled = useMemo(() => sessionCount >= 3, [sessionCount]);
+
+  const ensureBackgroundFileForCreate = useCallback(async () => {
+    if (backgroundFile) {
+      return backgroundFile;
+    }
+    if (backgroundUrl) {
+      return cloneFileFromUrl(backgroundUrl);
+    }
+    return undefined;
+  }, [backgroundFile, backgroundUrl]);
+
+  const handleCreate = useCallback(
+    async (title: string) => {
+      if (!title.trim()) {
+        showToast('Please enter a session name.', 'error');
+        return;
+      }
+      if (saveAsDisabled) {
+        showToast('Limit 3 sessions per user. Delete or overwrite.', 'error');
+        return;
+      }
+      setIsSaving(true);
+      try {
+        const bgFileForCreate = await ensureBackgroundFileForCreate();
+        const drawing = await createDrawing(title.trim(), getScene(), bgFileForCreate);
+        setCurrentDrawingId(drawing.id);
+        setCurrentDrawingTitle(drawing.title);
+        commitBackground(drawing.bg_image_path ?? null);
+        showToast('Session saved.', 'success');
+        await onSessionsChanged();
+      } catch (error) {
+        if (error instanceof MaxSessionsError) {
+          showToast(error.message, 'error');
+        } else if (error instanceof Error) {
+          showToast(error.message, 'error');
+        } else {
+          showToast('Unable to save session.', 'error');
+        }
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [commitBackground, ensureBackgroundFileForCreate, getScene, onSessionsChanged, saveAsDisabled, setCurrentDrawingId, setCurrentDrawingTitle, showToast]
+  );
+
+  const handleOverwrite = useCallback(async () => {
+    if (!currentDrawingId) {
+      return;
+    }
+    setIsSaving(true);
+    try {
+      const newPath = await updateDrawing(currentDrawingId, getScene(), backgroundFile ?? undefined);
+      const resolvedPath = newPath ?? backgroundPath ?? null;
+      commitBackground(resolvedPath, backgroundUrl ?? null);
+      showToast('Session updated.', 'success');
+      await onSessionsChanged();
+    } catch (error) {
+      if (error instanceof Error) {
+        showToast(error.message, 'error');
+      } else {
+        showToast('Unable to update session.', 'error');
+      }
+    } finally {
+      setIsSaving(false);
+      setMenuOpen(false);
+    }
+  }, [
+    backgroundFile,
+    backgroundPath,
+    backgroundUrl,
+    commitBackground,
+    currentDrawingId,
+    getScene,
+    onSessionsChanged,
+    showToast
+  ]);
+
+  const promptForTitle = useCallback(
+    (initial?: string | null) => {
+      const title = window.prompt('Name this session', initial ?? '');
+      if (!title) {
+        return null;
+      }
+      return title.trim();
+    },
+    []
+  );
+
+  const handlePrimaryClick = useCallback(() => {
+    if (isSaving) {
+      return;
+    }
+    if (!hasCurrentDrawing) {
+      const title = promptForTitle();
+      if (title) {
+        void handleCreate(title);
+      }
+    } else {
+      setMenuOpen((open) => !open);
+    }
+  }, [handleCreate, hasCurrentDrawing, isSaving, promptForTitle]);
+
+  const handleSaveAs = useCallback(() => {
+    const title = promptForTitle(currentDrawingTitle);
+    if (title) {
+      setMenuOpen(false);
+      void handleCreate(title);
+    }
+  }, [currentDrawingTitle, handleCreate, promptForTitle]);
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <button
+        type="button"
+        onClick={handlePrimaryClick}
+        disabled={isSaving}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 8,
+          backgroundColor: '#2563eb',
+          color: '#fff',
+          border: 'none',
+          borderRadius: 999,
+          padding: '10px 20px',
+          fontWeight: 600,
+          minWidth: 140,
+          boxShadow: '0 10px 30px rgba(37, 99, 235, 0.35)'
+        }}
+      >
+        <span aria-hidden="true" style={{ fontSize: 18, lineHeight: 1 }}>
+          💾
+        </span>
+        {isSaving ? 'Saving…' : 'Save session'}
+      </button>
+      {hasCurrentDrawing && menuOpen ? (
+        <div
+          style={{
+            position: 'absolute',
+            top: 'calc(100% + 8px)',
+            right: 0,
+            backgroundColor: '#1e293b',
+            borderRadius: 8,
+            boxShadow: '0 20px 45px rgba(15, 23, 42, 0.45)',
+            padding: 12,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 8,
+            minWidth: 180,
+            zIndex: 20
+          }}
+        >
+          <button
+            type="button"
+            onClick={() => {
+              void handleOverwrite();
+            }}
+            disabled={isSaving}
+            style={{
+              background: 'transparent',
+              border: 'none',
+              color: '#e2e8f0',
+              textAlign: 'left',
+              padding: '8px 10px',
+              borderRadius: 6
+            }}
+          >
+            Overwrite “{currentDrawingTitle ?? 'Untitled'}”
+          </button>
+          <button
+            type="button"
+            onClick={handleSaveAs}
+            disabled={isSaving || saveAsDisabled}
+            style={{
+              background: 'transparent',
+              border: 'none',
+              color: saveAsDisabled ? 'rgba(226,232,240,0.5)' : '#e2e8f0',
+              textAlign: 'left',
+              padding: '8px 10px',
+              borderRadius: 6
+            }}
+            title={saveAsDisabled ? 'Limit 3 sessions per user. Delete or overwrite.' : undefined}
+          >
+            Save As…
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/SessionsDropdown.tsx
+++ b/components/SessionsDropdown.tsx
@@ -1,0 +1,331 @@
+'use client';
+
+import React, { useCallback, useMemo, useState } from 'react';
+import { deleteDrawing, loadDrawing, renameDrawing, type Drawing } from '@/lib/drawings';
+import { useDrawing } from '@/components/DrawingContext';
+import { useToast } from '@/components/ToastProvider';
+
+type SessionsDropdownProps = {
+  sessions: Drawing[];
+  onRefresh: () => Promise<void>;
+  isLoading?: boolean;
+};
+
+export function SessionsDropdown({ sessions, onRefresh, isLoading = false }: SessionsDropdownProps) {
+  const {
+    currentDrawingId,
+    currentDrawingTitle,
+    setScene,
+    setCurrentDrawingId,
+    setCurrentDrawingTitle,
+    setBackgroundFromUrl,
+    setBackgroundPath,
+    setBackgroundFile
+  } = useDrawing();
+  const { showToast } = useToast();
+  const [open, setOpen] = useState(false);
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const [workingId, setWorkingId] = useState<string | null>(null);
+
+  const sortedSessions = useMemo(() => {
+    return [...sessions].sort((a, b) => (a.updated_at < b.updated_at ? 1 : -1));
+  }, [sessions]);
+
+  const beginRename = useCallback((session: Drawing) => {
+    setRenamingId(session.id);
+    setRenameValue(session.title);
+  }, []);
+
+  const cancelRename = useCallback(() => {
+    setRenamingId(null);
+    setRenameValue('');
+  }, []);
+
+  const handleRenameCommit = useCallback(async () => {
+    if (!renamingId) {
+      return;
+    }
+    const newTitle = renameValue.trim();
+    if (!newTitle) {
+      showToast('Please enter a new session name.', 'error');
+      return;
+    }
+    setWorkingId(renamingId);
+    try {
+      await renameDrawing(renamingId, newTitle);
+      if (currentDrawingId === renamingId) {
+        setCurrentDrawingTitle(newTitle);
+      }
+      showToast('Session renamed.', 'success');
+      await onRefresh();
+      cancelRename();
+    } catch (error) {
+      if (error instanceof Error) {
+        showToast(error.message, 'error');
+      } else {
+        showToast('Unable to rename session.', 'error');
+      }
+    } finally {
+      setWorkingId(null);
+    }
+  }, [cancelRename, currentDrawingId, onRefresh, renamingId, renameValue, setCurrentDrawingTitle, showToast]);
+
+  const handleDelete = useCallback(
+    async (session: Drawing) => {
+      const confirmed = window.confirm(`Delete “${session.title}”? This cannot be undone.`);
+      if (!confirmed) {
+        return;
+      }
+      setWorkingId(session.id);
+      try {
+        await deleteDrawing(session.id);
+        if (currentDrawingId === session.id) {
+          setCurrentDrawingId(null);
+          setCurrentDrawingTitle(null);
+          setScene([]);
+          setBackgroundFromUrl(null);
+          setBackgroundPath(null);
+          setBackgroundFile(null);
+        }
+        showToast('Session deleted.', 'success');
+        await onRefresh();
+      } catch (error) {
+        if (error instanceof Error) {
+          showToast(error.message, 'error');
+        } else {
+          showToast('Unable to delete session.', 'error');
+        }
+      } finally {
+        setWorkingId(null);
+      }
+    },
+    [currentDrawingId, onRefresh, setBackgroundFile, setBackgroundFromUrl, setBackgroundPath, setCurrentDrawingId, setCurrentDrawingTitle, setScene, showToast]
+  );
+
+  const handleLoad = useCallback(
+    async (session: Drawing) => {
+      setWorkingId(session.id);
+      try {
+        const payload = await loadDrawing(session.id);
+        setScene(payload.elements);
+        setBackgroundFromUrl(payload.bgUrl);
+        setBackgroundPath(session.bg_image_path ?? null);
+        setCurrentDrawingId(session.id);
+        setCurrentDrawingTitle(session.title);
+        showToast(`Loaded “${session.title}”.`, 'success');
+      } catch (error) {
+        if (error instanceof Error) {
+          showToast(error.message, 'error');
+        } else {
+          showToast('Unable to load session.', 'error');
+        }
+      } finally {
+        setWorkingId(null);
+        setOpen(false);
+      }
+    },
+    [setBackgroundFromUrl, setBackgroundPath, setCurrentDrawingId, setCurrentDrawingTitle, setScene, showToast]
+  );
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        disabled={isLoading}
+        style={{
+          backgroundColor: '#1f2937',
+          color: '#f8fafc',
+          borderRadius: 8,
+          border: '1px solid rgba(148, 163, 184, 0.3)',
+          padding: '10px 18px',
+          minWidth: 140,
+          fontWeight: 600
+        }}
+      >
+        Sessions ▾
+      </button>
+      {open ? (
+        <div
+          style={{
+            position: 'absolute',
+            top: 'calc(100% + 8px)',
+            right: 0,
+            width: 320,
+            backgroundColor: '#0f172a',
+            borderRadius: 12,
+            boxShadow: '0 25px 60px rgba(15, 23, 42, 0.55)',
+            padding: 16,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 16,
+            zIndex: 30
+          }}
+        >
+          <div style={{ color: '#94a3b8', fontSize: 14 }}>
+            Current: {currentDrawingTitle ? `“${currentDrawingTitle}”` : 'None loaded'}
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            {sortedSessions.length === 0 ? (
+              <span style={{ color: '#94a3b8' }}>No sessions yet.</span>
+            ) : (
+              sortedSessions.map((session) => {
+                const isRenaming = renamingId === session.id;
+                const isCurrent = currentDrawingId === session.id;
+                const busy = workingId === session.id;
+                return (
+                  <div
+                    key={session.id}
+                    style={{
+                      border: '1px solid rgba(148, 163, 184, 0.2)',
+                      borderRadius: 10,
+                      padding: 12,
+                      backgroundColor: isCurrent ? 'rgba(59, 130, 246, 0.15)' : 'rgba(15, 23, 42, 0.65)',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: 8
+                    }}
+                  >
+                    {isRenaming ? (
+                      <input
+                        value={renameValue}
+                        onChange={(event) => setRenameValue(event.target.value)}
+                        onKeyDown={(event) => {
+                          if (event.key === 'Enter') {
+                            event.preventDefault();
+                            void handleRenameCommit();
+                          }
+                          if (event.key === 'Escape') {
+                            event.preventDefault();
+                            cancelRename();
+                          }
+                        }}
+                        style={{
+                          padding: '6px 8px',
+                          borderRadius: 6,
+                          border: '1px solid rgba(148, 163, 184, 0.4)',
+                          background: '#020617',
+                          color: '#f8fafc'
+                        }}
+                        autoFocus
+                      />
+                    ) : (
+                      <div style={{ fontWeight: 600, color: '#f8fafc' }}>{session.title}</div>
+                    )}
+                    <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                      {isRenaming ? (
+                        <>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              void handleRenameCommit();
+                            }}
+                            disabled={busy}
+                            style={{
+                              padding: '6px 10px',
+                              borderRadius: 6,
+                              border: 'none',
+                              backgroundColor: '#2563eb',
+                              color: '#fff',
+                              fontWeight: 600
+                            }}
+                          >
+                            Save
+                          </button>
+                          <button
+                            type="button"
+                            onClick={cancelRename}
+                            style={{
+                              padding: '6px 10px',
+                              borderRadius: 6,
+                              border: '1px solid rgba(148, 163, 184, 0.3)',
+                              background: 'transparent',
+                              color: '#e2e8f0'
+                            }}
+                          >
+                            Cancel
+                          </button>
+                        </>
+                      ) : (
+                        <>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              void handleLoad(session);
+                            }}
+                            disabled={busy}
+                            style={{
+                              padding: '6px 10px',
+                              borderRadius: 6,
+                              border: 'none',
+                              backgroundColor: '#16a34a',
+                              color: '#fff',
+                              fontWeight: 600
+                            }}
+                          >
+                            Load
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => beginRename(session)}
+                            disabled={busy}
+                            style={{
+                              padding: '6px 10px',
+                              borderRadius: 6,
+                              border: '1px solid rgba(148, 163, 184, 0.4)',
+                              background: 'transparent',
+                              color: '#e2e8f0'
+                            }}
+                          >
+                            Rename
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              void handleDelete(session);
+                            }}
+                            disabled={busy}
+                            style={{
+                              padding: '6px 10px',
+                              borderRadius: 6,
+                              border: '1px solid rgba(248, 113, 113, 0.5)',
+                              background: 'transparent',
+                              color: '#f87171'
+                            }}
+                          >
+                            Delete
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', color: '#94a3b8' }}>
+            <span>{sortedSessions.length >= 3 ? 'Limit reached (3 sessions).' : ''}</span>
+            <button
+              type="button"
+              onClick={() => {
+                setOpen(false);
+                void onRefresh();
+              }}
+              disabled={isLoading}
+              style={{
+                padding: '6px 12px',
+                borderRadius: 6,
+                border: '1px solid rgba(148, 163, 184, 0.4)',
+                background: 'transparent',
+                color: '#e2e8f0'
+              }}
+            >
+              Refresh
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/components/ToastProvider.tsx
+++ b/components/ToastProvider.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+
+type ToastType = 'success' | 'error' | 'info';
+
+type Toast = {
+  id: string;
+  message: string;
+  type: ToastType;
+};
+
+type ToastContextValue = {
+  showToast: (message: string, type?: ToastType, durationMs?: number) => void;
+};
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined);
+
+const DEFAULT_DURATION = 4000;
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const removeToast = useCallback((id: string) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const showToast = useCallback(
+    (message: string, type: ToastType = 'info', durationMs: number = DEFAULT_DURATION) => {
+      const id = crypto.randomUUID();
+      setToasts((current) => [...current, { id, message, type }]);
+      window.setTimeout(() => removeToast(id), durationMs);
+    },
+    [removeToast]
+  );
+
+  const value = useMemo(() => ({ showToast }), [showToast]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div
+        aria-live="polite"
+        aria-atomic="true"
+        style={{
+          position: 'fixed',
+          top: 16,
+          right: 16,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 12,
+          zIndex: 1000
+        }}
+      >
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            style={{
+              backgroundColor:
+                toast.type === 'success' ? '#16a34a' : toast.type === 'error' ? '#dc2626' : '#334155',
+              color: '#f8fafc',
+              padding: '12px 16px',
+              borderRadius: 8,
+              boxShadow: '0 10px 30px rgba(15,23,42,0.35)',
+              minWidth: 240
+            }}
+          >
+            {toast.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast(): ToastContextValue {
+  const ctx = useContext(ToastContext);
+  if (!ctx) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  return ctx;
+}

--- a/lib/drawings.ts
+++ b/lib/drawings.ts
@@ -1,0 +1,240 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseClient } from './supabaseClient';
+
+export type SceneElement = {
+  id: string;
+  type: 'image' | 'rect' | 'text';
+  x: number;
+  y: number;
+  w?: number;
+  h?: number;
+  rotation?: number;
+  scale?: number;
+  z?: number;
+  src?: string;
+  text?: string;
+  style?: { fill?: string; stroke?: string; [k: string]: unknown };
+  locked?: boolean;
+};
+
+export type Drawing = {
+  id: string;
+  owner: string;
+  title: string;
+  elements: SceneElement[];
+  bg_image_path: string | null;
+  updated_at: string;
+};
+
+const DRAWINGS_TABLE = 'drawings';
+const DRAWING_IMAGES_BUCKET = 'drawing-images';
+const MAX_SESSIONS = 3;
+
+export class MaxSessionsError extends Error {
+  constructor() {
+    super('Limit 3 sessions per user. Delete or overwrite.');
+    this.name = 'MaxSessionsError';
+  }
+}
+
+type SupabaseUser = {
+  id: string;
+};
+
+async function requireUser(client: SupabaseClient): Promise<SupabaseUser> {
+  const { data, error } = await client.auth.getUser();
+  if (error || !data?.user) {
+    throw new Error('You must be signed in to manage sessions.');
+  }
+  return { id: data.user.id };
+}
+
+function getFileExtension(file: File): string {
+  const mimeExtension = file.type.split('/')[1];
+  if (mimeExtension) {
+    return mimeExtension;
+  }
+  const parts = file.name.split('.');
+  return parts.length > 1 ? parts.pop() ?? 'png' : 'png';
+}
+
+async function uploadBackgroundImage(
+  client: SupabaseClient,
+  ownerId: string,
+  drawingId: string,
+  file: File
+): Promise<string> {
+  const ext = getFileExtension(file);
+  const path = `${ownerId}/${drawingId}.${ext}`;
+  // Use upsert=true to replace existing assets without requiring an explicit delete.
+  const { error } = await client.storage
+    .from(DRAWING_IMAGES_BUCKET)
+    .upload(path, file, { upsert: true, cacheControl: '3600', contentType: file.type || 'image/png' });
+  if (error) {
+    throw error;
+  }
+  return path;
+}
+
+export async function getSignedUrl(path: string, expiresInSeconds = 3600): Promise<string> {
+  const client = getSupabaseClient();
+  const { data, error } = await client.storage
+    .from(DRAWING_IMAGES_BUCKET)
+    .createSignedUrl(path, expiresInSeconds);
+  if (error || !data?.signedUrl) {
+    throw error ?? new Error('Unable to create signed URL.');
+  }
+  return data.signedUrl;
+}
+
+export async function listDrawings(): Promise<Drawing[]> {
+  const client = getSupabaseClient();
+  await requireUser(client);
+  const { data, error } = await client
+    .from(DRAWINGS_TABLE)
+    .select('*')
+    .order('updated_at', { ascending: false })
+    .limit(MAX_SESSIONS);
+  if (error) {
+    throw error;
+  }
+  return (data ?? []) as Drawing[];
+}
+
+export async function createDrawing(
+  title: string,
+  elements: SceneElement[],
+  bgFile?: File
+): Promise<Drawing> {
+  const client = getSupabaseClient();
+  const user = await requireUser(client);
+
+  const { count, error: countError } = await client
+    .from(DRAWINGS_TABLE)
+    .select('*', { count: 'exact', head: true });
+  if (countError) {
+    throw countError;
+  }
+  if ((count ?? 0) >= MAX_SESSIONS) {
+    throw new MaxSessionsError();
+  }
+
+  const drawingId = crypto.randomUUID();
+  let bgImagePath: string | null = null;
+  if (bgFile) {
+    bgImagePath = await uploadBackgroundImage(client, user.id, drawingId, bgFile);
+  }
+
+  const insertPayload = {
+    id: drawingId,
+    owner: user.id,
+    title,
+    elements,
+    bg_image_path: bgImagePath,
+    updated_at: new Date().toISOString()
+  } satisfies Partial<Drawing> & { owner: string; title: string; elements: SceneElement[] };
+
+  const { data, error } = await client.from(DRAWINGS_TABLE).insert(insertPayload).select().single();
+  if (error) {
+    if (error.code === '23505') {
+      throw new Error('You already have a session with that name.');
+    }
+    if (error.code === 'P0001') {
+      throw new MaxSessionsError();
+    }
+    throw error;
+  }
+  return data as Drawing;
+}
+
+export async function updateDrawing(
+  id: string,
+  elements: SceneElement[],
+  bgFile?: File
+): Promise<string | undefined> {
+  const client = getSupabaseClient();
+  const user = await requireUser(client);
+  const updateData: Partial<Drawing> = {
+    elements,
+    updated_at: new Date().toISOString()
+  };
+
+  let uploadedPath: string | undefined;
+  if (bgFile) {
+    const path = await uploadBackgroundImage(client, user.id, id, bgFile);
+    updateData.bg_image_path = path;
+    uploadedPath = path;
+  }
+
+  const { error } = await client.from(DRAWINGS_TABLE).update(updateData).eq('id', id);
+  if (error) {
+    throw error;
+  }
+  return uploadedPath;
+}
+
+export async function renameDrawing(id: string, newTitle: string): Promise<void> {
+  const client = getSupabaseClient();
+  await requireUser(client);
+  const { error } = await client
+    .from(DRAWINGS_TABLE)
+    .update({ title: newTitle, updated_at: new Date().toISOString() })
+    .eq('id', id);
+  if (error) {
+    if (error.code === '23505') {
+      throw new Error('You already have a session with that name.');
+    }
+    throw error;
+  }
+}
+
+export async function deleteDrawing(id: string): Promise<void> {
+  const client = getSupabaseClient();
+  await requireUser(client);
+  const { data: existing, error: selectError } = await client
+    .from(DRAWINGS_TABLE)
+    .select('bg_image_path')
+    .eq('id', id)
+    .single();
+  if (selectError) {
+    throw selectError;
+  }
+
+  const { error: deleteError } = await client.from(DRAWINGS_TABLE).delete().eq('id', id);
+  if (deleteError) {
+    throw deleteError;
+  }
+
+  const path = (existing as { bg_image_path: string | null } | null)?.bg_image_path;
+  if (path) {
+    const { error: storageError } = await client.storage.from(DRAWING_IMAGES_BUCKET).remove([path]);
+    if (storageError) {
+      // Surface the storage error so the UI can notify the user, but the DB delete already succeeded.
+      throw storageError;
+    }
+  }
+}
+
+export async function loadDrawing(id: string): Promise<{ elements: SceneElement[]; bgUrl: string | null }> {
+  const client = getSupabaseClient();
+  await requireUser(client);
+  const { data, error } = await client
+    .from(DRAWINGS_TABLE)
+    .select('elements, bg_image_path')
+    .eq('id', id)
+    .single();
+  if (error) {
+    throw error;
+  }
+
+  const record = data as { elements: SceneElement[]; bg_image_path: string | null };
+  let bgUrl: string | null = null;
+  if (record.bg_image_path) {
+    bgUrl = await getSignedUrl(record.bg_image_path);
+  }
+
+  return {
+    elements: record.elements ?? [],
+    bgUrl
+  };
+}

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,0 +1,31 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+let browserClient: SupabaseClient | null = null;
+
+export function getSupabaseClient(): SupabaseClient {
+  if (browserClient) {
+    return browserClient;
+  }
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !anonKey) {
+    throw new Error(
+      'Supabase client is not configured. Please set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.'
+    );
+  }
+
+  browserClient = createClient(url, anonKey, {
+    auth: {
+      persistSession: true,
+      detectSessionInUrl: true
+    }
+  });
+
+  return browserClient;
+}
+
+export function __setSupabaseClientForTests(client: SupabaseClient | null) {
+  browserClient = client;
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "tdisney",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.39.7",
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.10.5",
+    "@types/react": "18.2.37",
+    "@types/react-dom": "18.2.15",
+    "eslint": "8.56.0",
+    "eslint-config-next": "14.1.0",
+    "typescript": "5.3.3",
+    "vitest": "1.1.1"
+  }
+}

--- a/supabase/sql/drawings.sql
+++ b/supabase/sql/drawings.sql
@@ -1,0 +1,82 @@
+-- Table for storing per-user drawing sessions.
+create table if not exists public.drawings (
+  id uuid primary key default gen_random_uuid(),
+  owner uuid not null references auth.users(id) on delete cascade,
+  title text not null,
+  elements jsonb not null default '[]',
+  bg_image_path text,
+  updated_at timestamptz not null default now(),
+  unique (owner, title)
+);
+
+alter table public.drawings enable row level security;
+
+create policy if not exists "owner select"
+  on public.drawings for select
+  using (owner = auth.uid());
+
+create policy if not exists "owner insert"
+  on public.drawings for insert
+  with check (owner = auth.uid());
+
+create policy if not exists "owner update"
+  on public.drawings for update
+  using (owner = auth.uid())
+  with check (owner = auth.uid());
+
+create policy if not exists "owner delete"
+  on public.drawings for delete
+  using (owner = auth.uid());
+
+-- Trigger to enforce the three-session-per-user cap at the database level.
+create or replace function public.enforce_drawing_limit()
+returns trigger as $$
+begin
+  if (select count(*) from public.drawings where owner = new.owner) >= 3 then
+    raise exception 'Limit 3 sessions per user. Delete or overwrite.' using errcode = 'P0001';
+  end if;
+  return new;
+end;
+$$ language plpgsql security definer;
+
+drop trigger if exists trg_enforce_drawing_limit on public.drawings;
+create trigger trg_enforce_drawing_limit
+  before insert on public.drawings
+  for each row execute function public.enforce_drawing_limit();
+
+-- Private bucket for persisted background images.
+insert into storage.buckets (id, name, public) values ('drawing-images', 'drawing-images', false)
+  on conflict (id) do nothing;
+
+-- Storage policies: signed URLs only, owners can read/write their own assets.
+create policy if not exists "owner can upload" on storage.objects for insert
+  with check (
+    bucket_id = 'drawing-images'
+    and auth.role() = 'authenticated'
+    and split_part(name, '/', 1) = auth.uid()::text
+  );
+
+create policy if not exists "owner can update" on storage.objects for update
+  using (
+    bucket_id = 'drawing-images'
+    and auth.role() = 'authenticated'
+    and split_part(name, '/', 1) = auth.uid()::text
+  )
+  with check (
+    bucket_id = 'drawing-images'
+    and split_part(name, '/', 1) = auth.uid()::text
+  );
+
+create policy if not exists "owner can delete" on storage.objects for delete
+  using (
+    bucket_id = 'drawing-images'
+    and auth.role() = 'authenticated'
+    and split_part(name, '/', 1) = auth.uid()::text
+  );
+
+create policy if not exists "owner can read via signed url" on storage.objects for select
+  using (
+    bucket_id = 'drawing-images'
+    and auth.role() = 'authenticated'
+    and split_part(name, '/', 1) = auth.uid()::text
+  );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -12,18 +16,30 @@
     "moduleResolution": "node",
     "baseUrl": ".",
     "paths": {
-      "@/*": ["*"]
+      "@/*": [
+        "*"
+      ]
     },
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": ["vitest/globals"]
+    "types": [
+      "vitest/globals"
+    ],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
   "include": [
     "next-env.d.ts",
     "**/*.ts",
-    "**/*.tsx"
+    "**/*.tsx",
+    ".next/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["*"]
+    },
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["vitest/globals"]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "framework": "nextjs",
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next"
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    environment: 'node'
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.')
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- surface the database trigger error for exceeding three saved sessions as a MaxSessionsError and return the uploaded path when overwriting backgrounds
- update the save button workflow to persist the latest storage path while keeping the active background preview in place
- rely on dropdown session metadata for stored paths and cover overwrite uploads with a new unit test

## Testing
- `npm install` *(fails: registry returns 403 for @supabase/supabase-js)*

------
https://chatgpt.com/codex/tasks/task_e_68d477ba16b0832fb4a90539235efa2a