### PR TITLE
Add local storage persistence for drawing sessions

### DIFF
--- a/components/DrawingContext.tsx
+++ b/components/DrawingContext.tsx
@@ -1,7 +1,17 @@
 'use client';
 
 import React, { createContext, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import type { SceneElement } from '@/lib/drawings';
+import { getSignedUrl, type SceneElement } from '@/lib/drawings';
+
+type PersistedDrawingState = {
+  currentDrawingId: string | null;
+  currentDrawingTitle: string | null;
+  elements: SceneElement[];
+  backgroundPath: string | null;
+  backgroundUrl: string | null;
+};
+
+const LOCAL_STORAGE_KEY = 'slipbot-studio-state-v1';
 
 type DrawingContextValue = {
   currentDrawingId: string | null;
@@ -30,6 +40,7 @@ export function DrawingProvider({ children }: { children: React.ReactNode }) {
   const [backgroundPath, setBackgroundPathState] = useState<string | null>(null);
   const [backgroundFile, setBackgroundFileState] = useState<File | null>(null);
   const objectUrlRef = useRef<string | null>(null);
+  const [isHydrated, setIsHydrated] = useState(false);
 
   useEffect(() => {
     return () => {
@@ -66,9 +77,9 @@ export function DrawingProvider({ children }: { children: React.ReactNode }) {
         setBackgroundUrl(url);
         setBackgroundFileState(null);
       },
-        setBackgroundPath: (path) => {
-          setBackgroundPathState(path);
-        },
+      setBackgroundPath: (path) => {
+        setBackgroundPathState(path);
+      },
       setBackgroundFile: (file) => {
         revokeObjectUrl();
         setBackgroundFileState(file);
@@ -92,6 +103,83 @@ export function DrawingProvider({ children }: { children: React.ReactNode }) {
       }
     };
   }, [backgroundFile, backgroundPath, backgroundUrl, currentDrawingId, currentDrawingTitle, elements]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    let isMounted = true;
+
+    const restoreState = async () => {
+      try {
+        const raw = window.localStorage.getItem(LOCAL_STORAGE_KEY);
+        if (!raw) {
+          return;
+        }
+
+        const parsed = JSON.parse(raw) as PersistedDrawingState;
+        setCurrentDrawingId(parsed.currentDrawingId ?? null);
+        setCurrentDrawingTitle(parsed.currentDrawingTitle ?? null);
+        setElements(parsed.elements ?? []);
+        setBackgroundPathState(parsed.backgroundPath ?? null);
+
+        if (parsed.backgroundPath) {
+          try {
+            const signedUrl = await getSignedUrl(parsed.backgroundPath);
+            if (isMounted) {
+              setBackgroundUrl(signedUrl);
+            }
+          } catch (error) {
+            console.error('Failed to restore background image', error);
+          }
+        } else if (isMounted) {
+          setBackgroundUrl(parsed.backgroundUrl ?? null);
+        }
+      } catch (error) {
+        console.error('Failed to restore drawing session state', error);
+        window.localStorage.removeItem(LOCAL_STORAGE_KEY);
+      } finally {
+        if (isMounted) {
+          setIsHydrated(true);
+        }
+      }
+    };
+
+    void restoreState();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isHydrated || typeof window === 'undefined') {
+      return;
+    }
+
+    const persistedState: PersistedDrawingState = {
+      currentDrawingId,
+      currentDrawingTitle,
+      elements,
+      backgroundPath,
+      backgroundUrl: backgroundPath || backgroundFile ? null : backgroundUrl
+    };
+
+    try {
+      window.localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(persistedState));
+    } catch (error) {
+      console.error('Failed to persist drawing session state', error);
+    }
+  }, [
+    backgroundFile,
+    backgroundPath,
+    backgroundUrl,
+    currentDrawingId,
+    currentDrawingTitle,
+    elements,
+    isHydrated
+  ]);
 
   return <DrawingContext.Provider value={value}>{children}</DrawingContext.Provider>;
 }


### PR DESCRIPTION
## Summary
- persist the current drawing metadata, elements, and background references to local storage so sessions survive reloads
- restore saved state on mount, including requesting new Supabase signed URLs when a background path is present
- guard persistence until client hydration and clear corrupt local storage payloads

## Testing
- npm test *(fails: `vitest` not found because dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d49ff37e8c832f94d484939b5ef17a